### PR TITLE
fix bulk_walk against noSuchInstance identifier

### DIFF
--- a/lib/Mojo/SNMP.pm
+++ b/lib/Mojo/SNMP.pm
@@ -518,7 +518,13 @@ sub _snmp_method_bulk_walk {
   my ($callback, $end, %tree, %types);
 
   $end = sub {
-    $session->pdu->var_bind_list(\%tree, \%types) if %tree;
+    if (scalar keys %tree) {
+      $session->pdu->var_bind_list(\%tree, \%types);
+    }
+    else {
+      $session->pdu->var_bind_list({$base_oid => 'noSuchInstance'},
+                                   {$base_oid => $Net::SNMP::NOSUCHINSTANCE});
+    }
     $session->$last;
     $end = $callback = undef;
   };

--- a/lib/Mojo/SNMP.pm
+++ b/lib/Mojo/SNMP.pm
@@ -522,8 +522,8 @@ sub _snmp_method_bulk_walk {
       $session->pdu->var_bind_list(\%tree, \%types);
     }
     else {
-      $session->pdu->var_bind_list({$base_oid => 'noSuchInstance'},
-                                   {$base_oid => $Net::SNMP::NOSUCHINSTANCE});
+      $session->pdu->var_bind_list({$base_oid => 'noSuchObject'},
+                                   {$base_oid => Net::SNMP::NOSUCHOBJECT});
     }
     $session->$last;
     $end = $callback = undef;

--- a/t/patch-bulkwalk-nosuchobject.t
+++ b/t/patch-bulkwalk-nosuchobject.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+use Test::More;
+use Mojo::SNMP;
+use constant TEST_MEMORY => $ENV{TEST_MEMORY} && eval 'use Test::Memory::Cycle; 1';
+
+plan skip_all => 'LIVE_TEST=0' unless $ENV{LIVE_TEST};
+
+my %T;
+
+sub d {
+  return if $T{"@_"}++;
+  diag(Data::Dumper->new([@_])->Terse(1)->Indent(0)->Dump);
+}
+
+my $snmp = Mojo::SNMP->new;
+my (@response, @error, $finish);
+
+$snmp->on(response => sub { push @response, $_[1]->var_bind_list });
+$snmp->on(error    => sub { push @error,    $_[1] });
+$snmp->on(finish   => sub { $finish++ });
+$snmp->defaults({community => 'public', version => 2});
+
+memory_cycle_ok($snmp) if TEST_MEMORY;
+
+@response = ();
+$snmp->prepare('127.0.0.1', {timeout => 1}, bulk_walk => ['1.3.6.1.2.1.1.3'])->wait;
+like $response[0]{'1.3.6.1.2.1.1.3.0'}, qr{\d}, 'bulk_walk uptime' or d $response[0];
+
+memory_cycle_ok($snmp) if TEST_MEMORY;
+
+@response = ();
+$snmp->prepare('127.0.0.1', {timeout => 1}, bulk_walk => ['1.3.6.1.2.1.1.3.0'])->wait;
+is $response[0]{'1.3.6.1.2.1.1.3.0'}, 'noSuchObject', '1.3.6.1.2.1.1.3.0 cannot be walked' or d $response[0];
+
+memory_cycle_ok($snmp) if TEST_MEMORY;
+
+@response = ();
+$snmp->prepare('127.0.0.1', {timeout => 1}, bulk_walk => ['1.3.6.1.2.1.1.888'])->wait;
+is $response[0]{'1.3.6.1.2.1.1.888'}, 'noSuchObject', '1.3.6.1.2.1.1.888 does not exist' or d $response[0];
+
+memory_cycle_ok($snmp) if TEST_MEMORY;
+
+@response = ();
+$snmp->prepare('127.0.0.1', {timeout => 1}, bulk_walk => ['1.3.6.1.2.1.1.888.0'])->wait;
+is $response[0]{'1.3.6.1.2.1.1.888.0'}, 'noSuchObject', '1.3.6.1.2.1.1.888.0 does not exist' or d $response[0];
+
+memory_cycle_ok($snmp) if TEST_MEMORY;
+
+done_testing;


### PR DESCRIPTION
Set `var_bind_list` to `noSuchInstance` when no results are returned from the `get_bulk_request`.

If `bulk_walk` is run against a missing identifier, then the initial `get_bulk_request()` will walk forward in the tree and retrieve values not matching the `oid_base`. However they are _already_ stored in the PDU by `Net::SNMP`, so the code in `$callback` to check `oid_base` never sees them.

This fix will always set/overwrite the `var_bind_list` within PDU, either to the returned and matching identifier-values, or to `noSuchInstance`.